### PR TITLE
Deploy 3x1D MS stations

### DIFF
--- a/files/KMCClusterFwd.cxx
+++ b/files/KMCClusterFwd.cxx
@@ -29,9 +29,9 @@ void KMCClusterFwd::Print(Option_t *opt) const
   TString opts = opt;
   opts.ToLower();
   if (opts.Contains("lc")) 
-    printf("Tr#%4d Loc (%+.4e,%+.4e %+.4e) %s",GetTrID(),fX,fY,fZ,IsKilled()?"Killed":""); 
+    printf("Tr#%4d TF (%+.4e,%+.4e %+.4e) %s",GetTrID(),GetXTF(), GetYTF(), GetZTF(),IsKilled()?"Killed":""); 
   else 
-    printf("Tr#%4d Lab (%+.4e,%+.4e %+.4e) %s",GetTrID(),GetXLab(),GetYLab(),GetZLab(),IsKilled()?"Killed":""); 
+    printf("Tr#%4d Lab (%+.4e,%+.4e %+.4e) %s",GetTrID(),GetX(),GetY(),GetZ(),IsKilled()?"Killed":""); 
   if (opts.Contains("nl")) return;
   printf("\n");
 }
@@ -42,8 +42,8 @@ Bool_t KMCClusterFwd::IsEqual(const TObject* obj) const
   // check if clusters are equal
   KMCClusterFwd* cl = (KMCClusterFwd*)obj;
   const double kTiny = 1e-12;
-  if (TMath::Abs(GetXLab()-cl->GetXLab())>kTiny || 
-      TMath::Abs(GetYLab()-cl->GetYLab())>kTiny) return kFALSE;
+  if (TMath::Abs(GetX()-cl->GetX())>kTiny || 
+      TMath::Abs(GetY()-cl->GetY())>kTiny) return kFALSE;
   return kTRUE;
 }
 
@@ -52,9 +52,9 @@ Int_t KMCClusterFwd::Compare(const TObject* obj) const
 {
   // compare 1st labx, then laby
   KMCClusterFwd* cl = (KMCClusterFwd*)obj;
-  if (GetXLab() > cl->GetXLab()) return -1; // tracking -Z = labX
-  if (GetXLab() < cl->GetXLab()) return  1;
-  if (GetYLab() < cl->GetYLab()) return -1; // tracking Y = labY
-  if (GetYLab() > cl->GetYLab()) return  1;
+  if (GetX() > cl->GetX()) return -1; // tracking -Z = labX
+  if (GetX() < cl->GetX()) return  1;
+  if (GetY() < cl->GetY()) return -1; // tracking Y = labY
+  if (GetY() > cl->GetY()) return  1;
   return 0;
 }

--- a/files/KMCClusterFwd.h
+++ b/files/KMCClusterFwd.h
@@ -19,9 +19,12 @@ class KMCClusterFwd : public TObject {
   Double_t GetX()    const   {return fX;}
   Double_t GetY()    const   {return fY;}
   Double_t GetZ()    const   {return fZ;}
-  Double_t GetXLab() const   {return -fZ;}
-  Double_t GetYLab() const   {return fY;}
-  Double_t GetZLab() const   {return fX;}
+  Double_t GetXLab() const   {return GetX();}
+  Double_t GetYLab() const   {return GetY();}
+  Double_t GetZLab() const   {return GetZ();}
+  Double_t GetXTF() const   {return fZ;}
+  Double_t GetYTF() const   {return fY;}
+  Double_t GetZTF() const   {return -fX;}
   void     SetX(double v)    {fX = v;}
   void     SetY(double v)    {fY = v;}
   void     SetZ(double v)    {fZ = v;}

--- a/files/KMCDetFwfLinkDef.h
+++ b/files/KMCDetFwfLinkDef.h
@@ -24,7 +24,9 @@
 #pragma link C++ class RotAngle+;
 #pragma link C++ class Sector+;
 #pragma link C++ class MeasPlane1D+;
+#pragma link C++ class FiredChannel+;
 #pragma link C++ class KMCMSSector+;
+#pragma link C++ class KMCMSStation+;
 
 // for installation w/o aliroot
 #pragma link C++ enum  LocLog::EType_t;

--- a/files/KMCDetFwfLinkDef.h
+++ b/files/KMCDetFwfLinkDef.h
@@ -21,6 +21,11 @@
 #pragma link C++ class BeamPipe+;
 #pragma link C++ class MagField+;
 
+#pragma link C++ class RotAngle+;
+#pragma link C++ class Sector+;
+#pragma link C++ class MeasPlane1D+;
+#pragma link C++ class KMCMSSector+;
+
 // for installation w/o aliroot
 #pragma link C++ enum  LocLog::EType_t;
 #pragma link C++ class TrackPar+;

--- a/files/KMCDetectorFwd.h
+++ b/files/KMCDetectorFwd.h
@@ -45,6 +45,7 @@ class KMCDetectorFwd : public TNamed {
   KMCPolyLayer* AddPolyLayer(const char *type, const char *name, Float_t zPos, Float_t radL, Float_t density,  Float_t thickness);
   KMCLayerFwd* AddLayer(const char *type, const char *name, Float_t zPos, Float_t radL, Float_t density,
                         Float_t thickness, Float_t xRes=999999, Float_t yRes=999999, Float_t eff=1, NaMaterial* mat=0);
+  void         AddLayer(KMCLayerFwd* lr, const char* type);
   void         AddBeamPipe(Float_t r, Float_t dr, Float_t radL, Float_t density, NaMaterial* mat=0);
   BeamPipe*    GetBeamPipe() const {return fBeamPipe;}
 
@@ -98,6 +99,7 @@ class KMCDetectorFwd : public TNamed {
   }
   
   //
+  void         PrepareForTracking();
   Bool_t       UpdateTrack(KMCProbeFwd* trc, const KMCLayerFwd* lr, const KMCClusterFwd* cl) const;
   Bool_t       NeedToKill(KMCProbeFwd* probe) const;
   Bool_t       GetUseBackground()          const {return fUseBackground;}

--- a/files/KMCDetectorFwd.h
+++ b/files/KMCDetectorFwd.h
@@ -11,6 +11,7 @@
 #include "KMCProbeFwd.h"
 #include "KMCClusterFwd.h"
 #include "KMCLayerFwd.h"
+#include "KMCMSStation.h"
 #include "KMCPolyLayer.h"
 #include "NaMaterial.h"
 #include <Riostream.h>
@@ -37,12 +38,13 @@ class KMCDetectorFwd : public TNamed {
   //
   void         ReadMaterials(const char* fname);
   void         ReadSetup(const char* setup, const char* materials);
+  void         Add3x1DMSStations(NaCardsInput *inp);
   TObjArray*   GetMaterials() const {return (TObjArray*)&fMaterials;}
   NaMaterial*  GetMaterial(const char* name) const {return (NaMaterial*)fMaterials.FindObject(name);}
   //
   KMCPolyLayer* AddPolyLayer(const char *type, const char *name, Float_t zPos, Float_t radL, Float_t density,  Float_t thickness);
   KMCLayerFwd* AddLayer(const char *type, const char *name, Float_t zPos, Float_t radL, Float_t density,
-                        Float_t thickness, Float_t xRes=999999, Float_t yRes=999999, Float_t eff=1,NaMaterial* mat=0);
+                        Float_t thickness, Float_t xRes=999999, Float_t yRes=999999, Float_t eff=1, NaMaterial* mat=0);
   void         AddBeamPipe(Float_t r, Float_t dr, Float_t radL, Float_t density, NaMaterial* mat=0);
   BeamPipe*    GetBeamPipe() const {return fBeamPipe;}
 

--- a/files/KMCLayerFwd.cxx
+++ b/files/KMCLayerFwd.cxx
@@ -88,4 +88,35 @@ KMCProbeFwd* KMCLayerFwd::GetWinnerMCTrack()
   return win;
 }
 
+//__________________________________________________________________________
+bool KMCLayerFwd::AddCluster(double x,double y,double z, Int_t id, bool isBG)
+{
+  double r = TMath::Sqrt(x*x + y*y); 
+  if (r>GetRMax() || r<GetRMin()) {
+    return false;
+  }
+  // store randomized cluster local coordinates and phi
+  double rx,ry;
+  gRandom->Rannor(rx,ry);
+  double xerr = rx*GetXRes(r), yerr = ry*GetYRes(r);
+  if (IsRPhiError()) { // rotate track position to R,phi
+    double phi = TMath::ATan2(y,x);
+    r += yerr;
+    double rphi = xerr;
+    double cs = TMath::Cos(phi), sn = TMath::Sin(phi);
+    x = r*cs - rphi*sn;
+    y = r*sn + rphi*cs;
+  } else {
+    x += xerr;
+    y += yerr;
+  }
+  if (isBG) {
+    AddBgCluster(x, y, z, id);
+  }
+  else {
+    GetMCCluster()->Kill(false);
+    GetMCCluster()->Set(x, y, z, id);
+  }
+  return true;
+}
 

--- a/files/KMCLayerFwd.h
+++ b/files/KMCLayerFwd.h
@@ -11,7 +11,7 @@ class KMCLayerFwd : public TNamed {
 public:
   enum {kTypeNA=-1,kVTX,kITS,kMS,kTRIG,kABS,kDUMMY,kMAG,kBitVertex=BIT(15)};
   enum {kMaxAccReg = 5};
-  KMCLayerFwd(const char *name);
+  KMCLayerFwd(const char *name = "");
   Float_t GetZ()         const {return fZ;}
   Float_t GetRMin()      const {return fRMin[0];}
   Float_t GetRMax()      const {return fRMax[fNAccReg-1];}

--- a/files/KMCLayerFwd.h
+++ b/files/KMCLayerFwd.h
@@ -6,6 +6,7 @@
 #include "KMCClusterFwd.h"
 #include "KMCProbeFwd.h"
 #include "NaMaterial.h"
+#include <TRandom.h>
 
 class KMCLayerFwd : public TNamed {
 public:
@@ -80,7 +81,9 @@ public:
   Bool_t  IsDummy()      const {return fType==kDUMMY;}
   Int_t   GetType()      const {return fType;}
   Bool_t  IsVertex()     const {return TestBit(kBitVertex);}
+  virtual void PrepareForTracking() {} 
   //
+  virtual bool          AddCluster(double x,double y,double z, Int_t id, bool isBG);
   Int_t                 AddBgCluster(double x,double y,double z, Int_t id);
   KMCClusterFwd*        GetBgCluster(Int_t i)    const {return (KMCClusterFwd*)fClBg[i];}
   TClonesArray*         GetBgClusters()          const {return (TClonesArray*)&fClBg;}
@@ -116,7 +119,7 @@ public:
   static void     SetDefEff(double eff=1) {fgDefEff = eff>1. ? 1.: (eff<0? 0:eff);}
   //
   Bool_t IsRPhiError() const { return fIsRPhiErr; }
-  void SetRPhiError(bool v) { fIsRPhiErr = v; }
+  virtual void SetRPhiError(bool v) { fIsRPhiErr = v; }
   //
  protected:
   //

--- a/files/KMCMSStation.cxx
+++ b/files/KMCMSStation.cxx
@@ -12,12 +12,13 @@ MeasPlane1D::MeasPlane1D(float phiSector, float dphih, float rmin, float rmax, f
 }
 
 KMCMSSector::KMCMSSector(float phiSector, float dphih, float rmin, float rmax,
-		     float phiUV, float pitchUV,
-		     float phiW, float pitchW)
+			 float phiUV, float pitchUV,
+			 float phiW, float pitchW, float _sigR, float _sigRPhi)
   : Sector(phiSector, dphih, rmin, rmax),
     stripPlaneU(phiSector, dphih, rmin, rmax, phiUV, pitchUV),
     stripPlaneV(phiSector, dphih, rmin, rmax, -phiUV, pitchUV),
-    wirePlaneW(phiSector, dphih, rmin, rmax, phiW, pitchW)
+    wirePlaneW(phiSector, dphih, rmin, rmax, phiW, pitchW),
+    sigR(_sigR), sigRPhi(_sigRPhi)
 {}
     
 bool KMCMSSector::getUVW(float x, float y, float& U, float& V, float& W) const
@@ -32,14 +33,15 @@ bool KMCMSSector::getUVW(float x, float y, float& U, float& V, float& W) const
 
 
 void KMCMSStation::init(int nsect, const std::vector<float>& r, const std::vector<float>& _phiUV, const std::vector<float>& _pitchUV,
-	    const std::vector<float>& _phiW, const std::vector<float>& _pitchW)
+	    const std::vector<float>& _phiW, const std::vector<float>& _pitchW,
+	    const std::vector<float>& _sigR, const std::vector<float>& _sigRPhi)
 {
   dPhi = TMath::Pi()*2./nsect;
   nRadSegments = r.size()-1;
   for (int ip=0;ip<nsect;ip++) {
     float phiSect = (ip+0.5)*dPhi;
     for (int ir=0;ir<nRadSegments;ir++) {
-      sectors.emplace_back(phiSect, 0.5*dPhi, r[ir], r[ir+1], _phiUV[ir], _pitchUV[ir], _phiW[ir], _pitchW[ir]);
+      sectors.emplace_back(phiSect, 0.5*dPhi, r[ir], r[ir+1], _phiUV[ir], _pitchUV[ir], _phiW[ir], _pitchW[ir], _sigR[ir], _sigRPhi[ir]);
     }
   }
 }

--- a/files/KMCMSStation.cxx
+++ b/files/KMCMSStation.cxx
@@ -1,10 +1,9 @@
 #include "KMCMSStation.h"
 
 MeasPlane1D::MeasPlane1D(float phiSector, float dphih, float rmin, float rmax, float phiMeas, float ptc)
-  : Sector(phiSector, dphih, rmin, rmax), measAngle(phiMeas), pitch(ptc)
+  : Sector(phiSector, dphih, rmin, rmax), pitch(ptc), offset(0), measAngle(phiMeas)
 {
   // find offset
-  float x,y;
   float chan = get1DMeasurement(rMin, rMin*TMath::Tan(dphiH));
   chan = TMath::Min(chan, get1DMeasurement(rMin, -rMin*TMath::Tan(dphiH)));
   chan = TMath::Min(chan, get1DMeasurement(rMax,  rMax*TMath::Tan(dphiH)));
@@ -29,4 +28,38 @@ bool KMCMSSector::getUVW(float x, float y, float& U, float& V, float& W) const
   V = stripPlaneV.get1DMeasurement(xl,yl);
   W = wirePlaneW.get1DMeasurement(xl,yl);
   return true;
+}
+
+
+void KMCMSStation::init(int nsect, const std::vector<float>& r, const std::vector<float>& _phiUV, const std::vector<float>& _pitchUV,
+	    const std::vector<float>& _phiW, const std::vector<float>& _pitchW)
+{
+  dPhi = TMath::Pi()*2./nsect;
+  nRadSegments = r.size()-1;
+  for (int ip=0;ip<nsect;ip++) {
+    float phiSect = (ip+0.5)*dPhi;
+    for (int ir=0;ir<nRadSegments;ir++) {
+      sectors.emplace_back(phiSect, 0.5*dPhi, r[ir], r[ir+1], _phiUV[ir], _pitchUV[ir], _phiW[ir], _pitchW[ir]);
+    }
+  }
+}
+
+int KMCMSStation::getSectorID(float x, float y) const
+{
+  float phi = TMath::ATan2(y,x);
+  if (phi<0) phi += TMath::Pi()*2;
+  int id = phi/dPhi;
+  if (id>=nSectors) id = nSectors-1;
+  id *= nRadSegments;
+  const auto& s0 = sectors[id]; // lowest segment of given sector;
+  float xl, yl;
+  s0.rotateToSector(x,y, xl,yl); // in this frame local X axis goes along bisector of the sector
+  if (xl<s0.rMin) return -1; // not in the acceptance
+  for (int ir=0;ir<nRadSegments;ir++) {
+    if (xl<sectors[id].rMax) {
+      return id;
+    }
+    id++;
+  }
+  return -1; // missed from top
 }

--- a/files/KMCMSStation.cxx
+++ b/files/KMCMSStation.cxx
@@ -18,6 +18,9 @@ KMCMSSector::KMCMSSector(float phiSector, float dphih, float rmin, float rmax,
     stripPlaneU(phiSector, dphih, rmin, rmax, phiUV, pitchUV),
     stripPlaneV(phiSector, dphih, rmin, rmax, -phiUV, pitchUV),
     wirePlaneW(phiSector, dphih, rmin, rmax, phiW, pitchW),
+    cUV(TMath::Cos(2.*phiUV)), sUV(TMath::Sin(2.*phiUV)),
+    cUW(TMath::Cos(phiUV - phiW)), sUW(TMath::Sin(phiUV - phiW)),
+    cVW(TMath::Cos(-phiUV - phiW)), sVW(TMath::Sin(-phiUV - phiW)),
     sigR(_sigR), sigRPhi(_sigRPhi)
 {}
     
@@ -31,12 +34,20 @@ bool KMCMSSector::getUVW(float x, float y, float& U, float& V, float& W) const
   return true;
 }
 
+void KMCMSSector::clear()
+{
+  stripPlaneU.clear();
+  stripPlaneV.clear();
+  wirePlaneW.clear();
+}
 
 void KMCMSStation::init(int nsect, const std::vector<float>& r, const std::vector<float>& _phiUV, const std::vector<float>& _pitchUV,
 	    const std::vector<float>& _phiW, const std::vector<float>& _pitchW,
 	    const std::vector<float>& _sigR, const std::vector<float>& _sigRPhi)
 {
   dPhi = TMath::Pi()*2./nsect;
+  nSectors = nsect;
+  radii = r;
   nRadSegments = r.size()-1;
   for (int ip=0;ip<nsect;ip++) {
     float phiSect = (ip+0.5)*dPhi;
@@ -64,4 +75,146 @@ int KMCMSStation::getSectorID(float x, float y) const
     id++;
   }
   return -1; // missed from top
+}
+
+//__________________________________________________________________________
+void KMCMSStation::Print(Option_t *opt) const
+{
+  KMCLayerFwd::Print(opt);
+  for (int ir=0;ir<nRadSegments;ir++) {
+    const KMCMSSector* sect =  getSector(ir);
+    printf("** %d 3x1D stations for %.1f<R<%.1f, coverage in phi: %.2f\n", nSectors, radii[ir],radii[ir+1], dPhi);
+    printf("** UV strip planes with angle: %.2f, pitch: %.1f, W plane with angle: %.2f, pitch: %.2f, sigmaR: %.3f, sigmaRPhi: %.3f\n",
+	   sect->stripPlaneU.sectAngle.phi0, sect->stripPlaneU.pitch, sect->wirePlaneW.sectAngle.phi0, sect->wirePlaneW.pitch, sect->sigR, sect->sigRPhi);
+  }
+}
+
+void KMCMSStation::SetRPhiError(bool)
+{
+  printf("3x1D station has always R/RPhi errors\n");
+  fIsRPhiErr = true;;
+}
+
+bool KMCMSStation::AddCluster(double x, double y, double z, Int_t id, bool isBG)
+{
+  if (!isBG) {
+    GetMCCluster()->Kill(true);
+  }
+  // store randomized cluster local coordinates and phi
+  signalSectorID = -1;
+  KMCMSSector* sect = getSector(x, y);
+  if (!sect) {
+    return false;
+  }
+  double r = TMath::Sqrt(x*x + y*y); 
+  double rx,ry;
+  gRandom->Rannor(rx,ry);  
+  double xerr = rx*sect->sigRPhi, yerr = ry*sect->sigR;
+  double phi = TMath::ATan2(y,x);
+  r += yerr;
+  double rphi = xerr;
+  double cs = TMath::Cos(phi), sn = TMath::Sin(phi);
+  x = r*cs - rphi*sn;
+  y = r*sn + rphi*cs;
+  int sid = getSectorID(x,y);
+  if (sid>=0) { 
+    sect = getSector(sid); // after randomization the sector might have changed, determine once more
+  }
+  float U,V,W;
+  bool res = sect->getUVW(x, y, U, V, W);
+  if (!res) {
+    return false;
+  }
+  if (!isBG) {
+    signalU = U;
+    signalV = V;
+    signalW = W;
+    signalSectorID = sid;
+    GetMCCluster()->Kill(false);
+    GetMCCluster()->Set(x, y, z, id);
+    
+  } else {
+    sect->stripPlaneU.hits.emplace_back(U, id);
+    sect->stripPlaneV.hits.emplace_back(V, id);
+    sect->wirePlaneW.hits.emplace_back(W, id);
+    AddBgCluster(x, y, z, id);
+  }
+  return true;
+}
+
+void KMCMSStation::PrepareForTracking()
+{
+  ResetBgClusters();
+  if (signalSectorID>=0) { // temporarily add signal channels to common channels pool
+    KMCMSSector* sect = getSector(signalSectorID);
+    sect->stripPlaneU.hits.emplace_back(signalU, -1);
+    sect->stripPlaneV.hits.emplace_back(signalV, -1);
+    sect->wirePlaneW.hits.emplace_back(signalW, -1);
+  }
+  for (size_t is=0;is<sectors.size();is++) {
+    KMCMSSector* sect = getSector(is);
+    for (size_t iu=0;iu<sect->stripPlaneU.hits.size();iu++) {
+      float hu = (sect->stripPlaneU.hits[iu].channel + sect->stripPlaneU.offset)*sect->stripPlaneU.pitch;
+      for (size_t iw=0;iw<sect->wirePlaneW.hits.size();iw++) {
+	float hw = (sect->wirePlaneW.hits[iw].channel + sect->wirePlaneW.offset)*sect->wirePlaneW.pitch;
+	// check crossing of U and W channels
+	float tuw = (hw - hu*sect->cUW)/sect->sUW; // this is a point on the U channel line corresponding to crossing with W channel
+	// rotate to sector frame
+	float xsUW=0, ysUW=0;
+	sect->stripPlaneU.local2sector(sect->stripPlaneU.hits[iu].channel, tuw, xsUW, ysUW);
+	/*
+	float xsUWlab=0, ysUWlab=0;
+	sect->sector2Lab(xsUW,ysUW, xsUWlab,ysUWlab);
+	printf("UW check for lbl %d %d: %f %f\n", sect->stripPlaneU.hits[iu].label, sect->wirePlaneW.hits[iw].label, xsUWlab,ysUWlab);
+	*/
+	if (!sect->isInside(xsUW, ysUW)) continue;
+	
+	for (size_t iv=0;iv<sect->stripPlaneV.hits.size();iv++) { // check crossing of VW channels
+	  float hv = (sect->stripPlaneV.hits[iv].channel + sect->stripPlaneV.offset)*sect->stripPlaneV.pitch;
+	  float tvw = (hw - hv*sect->cVW)/sect->sVW; // this is a point on the V channel line corresponding to crossing with W channel
+	  // rotate to sector frame
+	  float xsVW=0, ysVW=0;
+	  sect->stripPlaneV.local2sector(sect->stripPlaneV.hits[iv].channel, tvw, xsVW, ysVW);
+	  /*
+	  float xsVWlab=0, ysVWlab=0;
+	  sect->sector2Lab(xsVW,ysVW, xsVWlab,ysVWlab);
+	  printf("VW check for lbl %d %d: %f %f\n", sect->stripPlaneV.hits[iv].label, sect->wirePlaneW.hits[iw].label, xsVWlab,ysVWlab);
+	  */
+	  if (!sect->isInside(xsVW, ysVW)) continue;
+	  //
+	  // check distance between UW and VW crossings (should be within 3 sigma to be counted as a coincidence)
+	  float dx = xsUW-xsVW, dy = ysUW-ysVW;
+	  float chi2 = (dx*dx/sect->sigR + dy*dy/sect->sigRPhi)/2;
+	  if (chi2>9) continue;
+	  // register coincidence
+	  float xlab, ylab;
+	  sect->sector2Lab(0.5*(xsUW+xsVW), 0.5*(ysUW+ysVW), xlab, ylab);
+	  // determine label
+	  int lbl = 0;
+	  if (sect->stripPlaneU.hits[iu].label==sect->stripPlaneV.hits[iv].label &&
+	      sect->stripPlaneU.hits[iu].label==sect->wirePlaneW.hits[iw].label) {
+	    lbl = sect->stripPlaneU.hits[iu].label;
+	  } else {
+	    lbl = 100000 + sect->stripPlaneU.hits[iu].label;
+	  }
+	  if (lbl==-1) {
+	    fClMC.SetX(xlab);
+	    fClMC.SetY(ylab);
+	  } else {
+	    AddBgCluster(xlab,ylab,GetZ(),lbl);
+	  }	  
+	  printf("coincidence in sector %d: %f %f, chi2=%f, lbl: %d\n", int(is), xlab, ylab, chi2, lbl);
+	}
+      }
+    }
+
+  }
+  
+  if (signalSectorID>=0) { // temporarily add signal channels to common channels pool
+    KMCMSSector* sect = getSector(signalSectorID);
+    sect->stripPlaneU.hits.pop_back();
+    sect->stripPlaneV.hits.pop_back();
+    sect->wirePlaneW.hits.pop_back();
+  }
+  SortBGClusters();
 }

--- a/files/KMCMSStation.h
+++ b/files/KMCMSStation.h
@@ -12,10 +12,15 @@ struct RotAngle
   float csphi0;
   
   RotAngle(float phi=0) : phi0(phi), snphi0(TMath::Sin(phi)), csphi0(TMath::Cos(phi)) {}
-  void rotateZ(float x, float y, float& xr, float& yr) const
+  void rotateZToLocal(float x, float y, float& xr, float& yr) const
   {
    xr = x * csphi0 + y * snphi0;
    yr =-x * snphi0 + y * csphi0;
+  }
+  void rotateZFromLocal(float x, float y, float& xr, float& yr) const
+  {
+   xr = x * csphi0 - y * snphi0;
+   yr = x * snphi0 + y * csphi0;
   }
   ClassDefNV(RotAngle, 1);
 };
@@ -23,12 +28,22 @@ struct RotAngle
 struct Sector
 {
   Sector(float phi=0, float dphih=3.1415927, float rmin=0, float rmax=999.) : sectAngle(phi), dphiH(dphih), rMin(rmin), rMax(rmax) {}
-  bool rotateToSector(float x, float y, float &xloc, float &yloc) const   // if point inside, return local coordinates
+  bool isInside(float xS, float yS) const
   {
-    sectAngle.rotateZ(x,y, xloc, yloc);
-    float phi = TMath::ATan2(yloc,xloc);
-    return TMath::Abs(phi)<dphiH && x>rMin && x<rMax;
-  }  
+    // check if the point with sector coordinate belongs to the sector
+    float phi = TMath::ATan2(yS,xS);
+    return TMath::Abs(phi)<dphiH && xS>rMin && xS<rMax;
+  }
+  bool rotateToSector(float xlab, float ylab, float &xloc, float &yloc) const   // if point inside, return local coordinates
+  {
+    sectAngle.rotateZToLocal(xlab,ylab, xloc, yloc);
+    return isInside(xloc, yloc);
+  }
+  void sector2Lab(float xs, float ys, float &xl, float &yl) const
+  {
+    sectAngle.rotateZFromLocal(xs,ys, xl, yl);
+  }
+  
   RotAngle sectAngle; // bisector
   float dphiH; // phi half coverage
   float rMin; // min rad at bisector
@@ -36,16 +51,36 @@ struct Sector
   ClassDefNV(Sector, 1);
 };
 
+struct FiredChannel
+{
+  float channel;
+  short label;
+  FiredChannel(float _c=0, short _l=0) : channel(_c), label(_l) {}
+  ClassDefNV(FiredChannel,1);
+};
+
+
 struct MeasPlane1D : public Sector
 {
   MeasPlane1D(float phiSector=0, float dphih=TMath::Pi(), float rmin=0., float rmax=999., float phiMeas=0., float pitch=0.1);
   
   float get1DMeasurement(float x, float y) const
   {
+    // get channel corresponding to sector coordinate x,y (x axis along bisector)
     float xloc, yloc;
-    measAngle.rotateZ(x,y, xloc, yloc); // rotate to measurement plane
-    return xloc/pitch - offset;
+    measAngle.rotateZToLocal(x,y, xloc, yloc); // rotate to measurement plane
+    return yloc/pitch - offset;
   }
+  void local2sector(float channel, float t, float &x, float& y)
+  {
+    // get sector coordinates for channel and a pont on the line along the channel
+    float q = (channel + offset)*pitch;
+    measAngle.rotateZFromLocal(t, q, x, y); // rotate from measurement to sector frame
+  }
+  
+  void clear() { hits.clear(); }
+  
+  std::vector<FiredChannel> hits;
   float pitch;
   float offset;
   RotAngle measAngle; // inclination of the 1d measurement direction wrt mother frame
@@ -64,28 +99,40 @@ struct KMCMSSector : public Sector
   }
   
   bool getUVW(float x, float y, float& U, float& V, float& W) const;
+  void clear();
   MeasPlane1D stripPlaneU;
   MeasPlane1D stripPlaneV;
   MeasPlane1D wirePlaneW;
+  double cUV, sUV; // cos and sine of U,V angle differences
+  double cUW, sUW; // cos and sine of U,W angle differences
+  double cVW, sVW; // cos and sine of V,W angle differences
   float sigR;
   float sigRPhi;
-  
   ClassDefNV(KMCMSSector, 1);
 };
 
 struct KMCMSStation : public KMCLayerFwd
 {
-  KMCMSStation(const char *name = "") : KMCLayerFwd(name), nSectors(0), nRadSegments(0), dPhi(0) {}
+  KMCMSStation(const char *name = "") : KMCLayerFwd(name), nSectors(0), nRadSegments(0), dPhi(0),
+    signalU(-1.), signalV(-1.), signalW(-1.), signalSectorID(-1) {}
+  
   void init(int nsect, const std::vector<float>& r, const std::vector<float>& _phiUV, const std::vector<float>& _pitchUV,
 	    const std::vector<float>& _phiW, const std::vector<float>& _pitchW,
 	    const std::vector<float>& _sigR, const std::vector<float>& _sigRPhi);
   int getSectorID(float x, float y) const;
   KMCMSSector* getSector(int id) { return id<int(sectors.size()) ? &sectors[id] : 0; }
+  const KMCMSSector* getSector(int id) const { return id<int(sectors.size()) ? &sectors[id] : 0; }
   KMCMSSector* getSector(float x, float y) { return getSector( getSectorID(x,y) ); }
-
+  virtual bool AddCluster(double x,double y,double z, Int_t id, bool isBG);
+  virtual void Print(Option_t *opt) const;
+  virtual void SetRPhiError(bool );
+  virtual void PrepareForTracking();
+  
   int nSectors;               // number of sectors (each having 2pi/nSectors coverage)
   int nRadSegments;           // number of radial segments
   float dPhi;                 // sector coverage
+  float signalU, signalV, signalW; // signal channels cache
+  int signalSectorID;
   std::vector<float> radii;   // single sector may be made of a few trapezoidal segments delimited by these radii
   std::vector<KMCMSSector> sectors; // sectors ordered in phi.Each sector may have a few trapezoidal segments
   ClassDef(KMCMSStation, 1);

--- a/files/KMCMSStation.h
+++ b/files/KMCMSStation.h
@@ -55,7 +55,8 @@ struct MeasPlane1D : public Sector
 
 struct KMCMSSector : public Sector
 {
-  KMCMSSector(float phiSector=0, float dphih=TMath::Pi(), float rmin=0., float rmax=999., float phiUV=0., float pitchUV=0.1, float phiW=TMath::Pi()/2, float pitchW=0.1);
+  KMCMSSector(float phiSector=0, float dphih=TMath::Pi(), float rmin=0., float rmax=999., float phiUV=0., float pitchUV=0.1,
+	      float phiW=TMath::Pi()/2, float pitchW=0.1, float _sigR=0.03, float _sigRPhi=0.03);
 
   static KMCMSSector* createSectorDef(float phiSector, float dphih, float rmin, float rmax, float stereoAngle, float pitchUV, float pitchW)
   {
@@ -66,6 +67,8 @@ struct KMCMSSector : public Sector
   MeasPlane1D stripPlaneU;
   MeasPlane1D stripPlaneV;
   MeasPlane1D wirePlaneW;
+  float sigR;
+  float sigRPhi;
   
   ClassDefNV(KMCMSSector, 1);
 };
@@ -74,7 +77,8 @@ struct KMCMSStation : public KMCLayerFwd
 {
   KMCMSStation(const char *name = "") : KMCLayerFwd(name), nSectors(0), nRadSegments(0), dPhi(0) {}
   void init(int nsect, const std::vector<float>& r, const std::vector<float>& _phiUV, const std::vector<float>& _pitchUV,
-	    const std::vector<float>& _phiW, const std::vector<float>& _pitchW);
+	    const std::vector<float>& _phiW, const std::vector<float>& _pitchW,
+	    const std::vector<float>& _sigR, const std::vector<float>& _sigRPhi);
   int getSectorID(float x, float y) const;
   KMCMSSector* getSector(int id) { return id<int(sectors.size()) ? &sectors[id] : 0; }
   KMCMSSector* getSector(float x, float y) { return getSector( getSectorID(x,y) ); }

--- a/files/KMCMSStation.h
+++ b/files/KMCMSStation.h
@@ -3,14 +3,15 @@
 
 #include <TMath.h>
 #include <Rtypes.h>
+#include "KMCLayerFwd.h"
 
 struct RotAngle
 {
-  float phi0 = 0;
-  float snphi0 = 0;
-  float csphi0 = 0;
+  float phi0;
+  float snphi0;
+  float csphi0;
   
-  RotAngle(float phi) : phi0(phi), snphi0(TMath::Sin(phi)), csphi0(TMath::Cos(phi)) {}
+  RotAngle(float phi=0) : phi0(phi), snphi0(TMath::Sin(phi)), csphi0(TMath::Cos(phi)) {}
   void rotateZ(float x, float y, float& xr, float& yr) const
   {
    xr = x * csphi0 + y * snphi0;
@@ -29,15 +30,15 @@ struct Sector
     return TMath::Abs(phi)<dphiH && x>rMin && x<rMax;
   }  
   RotAngle sectAngle; // bisector
-  float dphiH = 0; // phi half coverage
-  float rMin = 0; // min rad at bisector
-  float rMax = 0; // max rad at bisector
+  float dphiH; // phi half coverage
+  float rMin; // min rad at bisector
+  float rMax; // max rad at bisector
   ClassDefNV(Sector, 1);
 };
 
 struct MeasPlane1D : public Sector
 {
-  MeasPlane1D(float phiSector, float dphih, float rmin, float rmax, float phiMeas, float pitch);
+  MeasPlane1D(float phiSector=0, float dphih=TMath::Pi(), float rmin=0., float rmax=999., float phiMeas=0., float pitch=0.1);
   
   float get1DMeasurement(float x, float y) const
   {
@@ -45,8 +46,8 @@ struct MeasPlane1D : public Sector
     measAngle.rotateZ(x,y, xloc, yloc); // rotate to measurement plane
     return xloc/pitch - offset;
   }
-  float pitch = 1;
-  float offset = 0;
+  float pitch;
+  float offset;
   RotAngle measAngle; // inclination of the 1d measurement direction wrt mother frame
 
   ClassDefNV(MeasPlane1D,1);
@@ -54,7 +55,7 @@ struct MeasPlane1D : public Sector
 
 struct KMCMSSector : public Sector
 {
-  KMCMSSector(float phiSector, float dphih, float rmin, float rmax, float phiUV, float pitchUV, float phiW, float pitchW);
+  KMCMSSector(float phiSector=0, float dphih=TMath::Pi(), float rmin=0., float rmax=999., float phiUV=0., float pitchUV=0.1, float phiW=TMath::Pi()/2, float pitchW=0.1);
 
   static KMCMSSector* createSectorDef(float phiSector, float dphih, float rmin, float rmax, float stereoAngle, float pitchUV, float pitchW)
   {
@@ -67,6 +68,23 @@ struct KMCMSSector : public Sector
   MeasPlane1D wirePlaneW;
   
   ClassDefNV(KMCMSSector, 1);
+};
+
+struct KMCMSStation : public KMCLayerFwd
+{
+  KMCMSStation(const char *name = "") : KMCLayerFwd(name), nSectors(0), nRadSegments(0), dPhi(0) {}
+  void init(int nsect, const std::vector<float>& r, const std::vector<float>& _phiUV, const std::vector<float>& _pitchUV,
+	    const std::vector<float>& _phiW, const std::vector<float>& _pitchW);
+  int getSectorID(float x, float y) const;
+  KMCMSSector* getSector(int id) { return id<int(sectors.size()) ? &sectors[id] : 0; }
+  KMCMSSector* getSector(float x, float y) { return getSector( getSectorID(x,y) ); }
+
+  int nSectors;               // number of sectors (each having 2pi/nSectors coverage)
+  int nRadSegments;           // number of radial segments
+  float dPhi;                 // sector coverage
+  std::vector<float> radii;   // single sector may be made of a few trapezoidal segments delimited by these radii
+  std::vector<KMCMSSector> sectors; // sectors ordered in phi.Each sector may have a few trapezoidal segments
+  ClassDef(KMCMSStation, 1);
 };
 
 #endif

--- a/files/KMCProbeFwd.h
+++ b/files/KMCProbeFwd.h
@@ -203,7 +203,7 @@ inline Bool_t KMCProbeFwd::Update(Double_t cov[3])
 {
   // dummy update with measurement errors in the plane normal to Z axis (in Lab X,Y axis) 
   //  printf("Before update %f %f %f\n",cov[0],cov[1],cov[2]); fTrack.Print();
-  double p[2] = {fTrack.GetY(), fTrack.GetZ()};
+  double p[2] = {GetX(), fTrack.GetY()};
   if (!fTrack.Update(p,cov)) return kFALSE;
   //  printf("After update: \n"); fTrack.Print();
   return kTRUE;  

--- a/files/Makefile
+++ b/files/Makefile
@@ -26,6 +26,7 @@ DICTO=	KMCDetFwdDict.o
 SRC = 	GenMUONLMR.cxx  KMCClusterFwd.cxx  KMCDetectorFwd.cxx  KMCFlukaParser.cxx \
 	KMCLayerFwd.cxx  KMCProbeFwd.cxx  KMCUtils.cxx NaMaterial.cxx \
         KMCPolyLayer.cxx KMCMagnetBuilder.cxx \
+        KMCMSStation.cxx \
         LocLog.cxx TrackPar.cxx TLocTreeStream.cxx
 
 HDR =	$(SRC:.cxx=.h) 

--- a/files/macros/runDiMuGenLMR.C
+++ b/files/macros/runDiMuGenLMR.C
@@ -1,5 +1,5 @@
 #if !defined(__CINT__) || defined(__MAKECINT__)
-#define _NOALIROOT_
+//#define _NOALIROOT_
 #include "KMCDetectorFwd.h"
 #include "KMCProbeFwd.h"
 #include "TLorentzVector.h"
@@ -147,6 +147,7 @@ void runDiMuGenLMR(int nev=30000,     // n events to generate
   det = new KMCDetectorFwd();
   //det->SetUseRPhiErrorMS(true);
   det->ReadSetup(setup,setup);
+  //  NBGPi=0; NBGKplus=0;NBGKminus=0;NBGP=0;
   //  det->InitBgGeneration(dndyBG,y0BG,sigyBG,yminBG,ymaxBG,TBG,ptminBG,ptmaxBG);
   det->InitBgGenerationPart(NBGPi,NBGKplus,NBGKminus,NBGP,Piratio,y0BG,y0BGPi,y0BGKplus,y0BGKminus,y0BGP,sigyBGPi,sigyBGKplus,sigyBGKminus,sigyBGP,yminBG,ymaxBG,TBGpi,TBGK,TBGP,ptminBG,ptmaxBG);
   // det->InitBgGenerationPart(0.,dndyBGK,0.,y0BG,sigyBG,yminBG,ymaxBG,TBGpi,TBGK,TBGP,ptminBG,ptmaxBG);

--- a/files/macros/runDiMuGenLMR.C
+++ b/files/macros/runDiMuGenLMR.C
@@ -1,5 +1,5 @@
 #if !defined(__CINT__) || defined(__MAKECINT__)
-//#define _NOALIROOT_
+#define _NOALIROOT_
 #include "KMCDetectorFwd.h"
 #include "KMCProbeFwd.h"
 #include "TLorentzVector.h"
@@ -147,7 +147,7 @@ void runDiMuGenLMR(int nev=30000,     // n events to generate
   det = new KMCDetectorFwd();
   //det->SetUseRPhiErrorMS(true);
   det->ReadSetup(setup,setup);
-  //  NBGPi=0; NBGKplus=0;NBGKminus=0;NBGP=0;
+  NBGPi=0; NBGKplus=0;NBGKminus=0;NBGP=0;
   //  det->InitBgGeneration(dndyBG,y0BG,sigyBG,yminBG,ymaxBG,TBG,ptminBG,ptmaxBG);
   det->InitBgGenerationPart(NBGPi,NBGKplus,NBGKminus,NBGP,Piratio,y0BG,y0BGPi,y0BGKplus,y0BGKminus,y0BGP,sigyBGPi,sigyBGKplus,sigyBGKminus,sigyBGP,yminBG,ymaxBG,TBGpi,TBGK,TBGP,ptminBG,ptmaxBG);
   // det->InitBgGenerationPart(0.,dndyBGK,0.,y0BG,sigyBG,yminBG,ymaxBG,TBGpi,TBGK,TBGP,ptminBG,ptmaxBG);

--- a/files/setups/setup_3x1d.txt
+++ b/files/setups/setup_3x1d.txt
@@ -1,0 +1,88 @@
+# keep this if slices are to be ordered in decreasing z
+define:zinverted
+
+# if not defined or -1 : Alice field, otherwise custom
+define:magfield  0
+
+#		r	dr	material
+#beampipe:	0.5	0.08    BERYLLIUM
+
+# dummy layer as a vertex	Zc	DZ		resX	resY
+vertex:		      		0.	0.		500e-4	500e-4
+
+# the parameters eff,RMin,RMax are optional (default is 1,0,1e9), but if one is there, preciding ones also should be set
+#		name		material	Zc	DZ		resX	resY	eff	RMin	RMax
+activelayer:vt	VT1		SILICON		7	400e-4 		10.e-4	10.e-4  0.9	0.1555 3.2875
+dummy:		VT1Plane	CARBON		7.07	1000e-4		
+activelayer:vt	VT2		SILICON		15	400e-4		10.e-4	10.e-4	0.9	0.3333 7.0446
+dummy:          VT2Plane        CARBON          15.07   1000e-4
+activelayer:vt	VT3		SILICON		20	400e-4		10.e-4	10.e-4	0.9	0.4444 9.3928
+dummy:          VT3Plane        CARBON          20.07   1000e-4
+activelayer:vt	VT4		SILICON		25	400e-4		10.e-4	10.e-4	0.9	0.5555 11.7411
+dummy:          VT4Plane        CARBON          25.07   1000e-4
+activelayer:vt	VT5		SILICON		38	400e-4		10.e-4	10.e-4	0.9	0.8444 17.8464
+dummy:          VT5Plane        CARBON          38.07   1000e-4
+#
+
+#activelayer:ms	MS-CH0		SILICON		624.	610e-4		200e-4	200e-4	0.95	6.5329 138.0749
+#activelayer:ms	MS-CH1		SILICON		691.	610e-4		200e-4	200e-4	0.95	30.000 169.5409
+#activelayer:ms	MS-CH2		SILICON	       1030.	700e-4		200e-4	200e-4	0.95	30.0000 311.164894
+#activelayer:ms	MS-CH3		SILICON	       1130.	700e-4		200e-4	200e-4	0.95	16.6656 355.617021
+#
+# UVstrip+Wire chambers:
+# expect format "active3x1D:type NAME MATERIAL Z DZ eff NSectors NSegments RMin NSegments*[RMax sigmaR sigmaRPhi phiUV pitchUV phiW pitchW]
+# the sector description is: RMax of radial segment, its sigmaR sigmaRPhi, phiUV of strip planes of pitchUV, phiW pitchW of wire chamber.
+# maximum KMCLayerFwd::kMaxAccReg-1 segments per sector is allowed, at least 1 should be provided 
+
+# example 12 azimuthal sectors made of 2 segments with radii 20<R<60 and 60<R<140 with UV stereo angle 10degree
+# (80 degree wrt bisector of the sector) and pitch of 3mm and wire plane with wires inclination 360/12/2 degree (parallel to sector edge at 1 side)
+# and pitch of 3mm and effective resolution of 0.02cm in R and 0.04cm in RPhi
+#
+active3x1D:ms MS-CH0 SILICON 624.  0.1 0.95 12 2 20.      60 0.02 0.04 1.396 0.3 0.26179939 0.3     140 0.02 0.04 1.396 0.3 0.26179939 0.3
+
+active3x1D:ms MS-CH1 SILICON 691.  0.1 0.95 12 2 20.      80 0.02 0.04 1.396 0.3 0.26179939 0.3     170 0.02 0.04 1.396 0.3 0.26179939 0.3
+active3x1D:ms MS-CH2 SILICON 1030. 0.1 0.95 12 2 20.      120 0.02 0.04 1.396 0.3 0.26179939 0.3     311 0.02 0.04 1.396 0.3 0.26179939 0.3
+active3x1D:ms MS-CH3 SILICON 1130. 0.1 0.95 12 2 20.      120 0.02 0.04 1.396 0.3 0.26179939 0.3     355 0.02 0.04 1.396 0.3 0.26179939 0.3
+
+
+
+# trigger chambers
+activelayer:tr	MS-TR1		SILICON	       1330.	1330e-4		0.1	0.1	0.95	26.6649 444.521277
+activelayer:tr	MS-TR2		SILICON	       1370.  	1330e-4		0.1	0.1	0.95	27.7759 462.302128
+
+#		name		material	Zc	DZ
+absorber:	ABS_BEO_0	BEO		96.8	106.4
+#absorber:	ABSO_C_0	CARBONA		175.0	30.00
+absorber:	ABSO_C_0	CARBONA		170.0	40.00
+absorber:	ABSO_C_1	CARBONA		200.0	20.00
+absorber:	ABSO_C_2	CARBONA		220.0	20.00
+absorber:	ABSO_FE_0	CARBONA		240.0	20.00
+absorber:	ABSO_FE_1	CARBONA		260.0	20.00
+absorber:	ABSO_FE_2	CARBONA		275.0	10.00
+absorber:	ABSO_FE_3	CARBONA		445.0  330.00
+
+#
+absorber:	ABSO_WALL	CARBONA		1230.0	180.00
+#
+
+############################################################
+######                                                ######
+######                   MATERIALS                    ######
+######                                                ######
+############################################################
+#           Name         A	Z	Density		RadL(g/cm2)	AbsL(g/cm2)	      I     PlasmaEnergy
+#	    
+material:   VACUUM      1.E-16  1.E-16	1.E-16		1.E16		1.E16                 1.E16	1.E16 
+material:   AIR         14.61   7.3   	1.205e-3  	36.6 		90.37                 85.7e-9    0.71e-9
+material:   BERYLLIUM   9.012   4.0    	1.848      	65.19    	56.30                 63.7e-9    26.10e-9
+material:   SILICON     28.09 	14.0	2.329         	21.82		70.2                 173.0e-9   31.05e-9
+
+#material:   BEO        	13.482  6.559   2.810  		40.548		100.73     93.2e-9    34.63e-9
+# Fluka BeO
+material:   BEO        	12.510  6.000   2.810  		41.307		100.73              93.2e-9    34.63e-9
+material:   IRON        55.85   26.0   	7.87       	13.84		81.7                 286.0e-9   55.17e-9
+material:   CARBON      12.01   6.0   	2.00      	42.70		59.2                 78.0e-9    30.28e-9
+material:   CARBONA     12.01   6.0     1.93            42.6916         59.2                 78.0e-9    30.28e-9
+material:   CERAMICS   	22.313  10.855  3.600           27.54		114.84               145.2e-9  40.21e-9
+material:   AL2O3      	21.812  10.646  3.520  		27.87  		114.92               145.2e-9  40.21e-9
+


### PR DESCRIPTION
```
# UVstrip+Wire chambers:
# Expected format "active3x1D:type NAME MATERIAL Z DZ eff NSectors NSegments RMin NSegments*[RMax sigmaR sigmaRPhi phiUV pitchUV phiW pitchW]
# the sector description is: RMax of radial segment, its sigmaR sigmaRPhi, phiUV of strip planes of pitchUV, phiW pitchW of wire chamber.
# maximum KMCLayerFwd::kMaxAccReg-1 segments per sector is allowed, at least 1 should be provided 

example 12 azimuthal sectors made of 2 segments with radii 20<R<60 and 60<R<140 with UV stereo angle 10degree
# (80 degree wrt bisector of the sector) and pitch of 3mm and wire plane with wires inclination 360/12/2 degree (parallel to sector edge at 1 side)
# and pitch of 3mm and effective resolution of 0.02cm in R and 0.04cm in RPhi
#
active3x1D:ms MS-CH0 SILICON 624.  0.1 0.95 12 2 20.      60 0.02 0.04 1.396 0.3 0.26179939 0.3     140 0.02 0.04 1.396 0.3 0.26179939 0.3
```